### PR TITLE
Improvement handling router login failures

### DIFF
--- a/src/api/erotik.erl
+++ b/src/api/erotik.erl
@@ -16,13 +16,17 @@
 -spec api_connect(string(), string(), integer(), string(), string()) -> {ok, pid()}.
 api_connect(Name, Host, Port, Login, Password) ->
 	Config = [{host, Host}, {port, Port}, {login, Login}, {password, Password}],
-	me_connector:start_link(Name, {api, Config}).
+	{ok, Pid} = me_connector:start_link(Name, []),
+	ok = gen_server:call(Pid, {connect, {api, Config}}, 10 * 1000),
+	{ok, Pid}.
 
 %% same as api_connect, but with timeout in milliseconds
 -spec api_connect(string(), string(), integer(), string(), string(), integer()) -> {ok, pid()}.
 api_connect(Name, Host, Port, Login, Password, Timeout) ->
 	Config = [{host, Host}, {port, Port}, {login, Login}, {password, Password}, {timeout, Timeout}],
-	me_connector:start_link(Name, {api, Config}).
+	{ok, Pid} = me_connector:start_link(Name, []),
+	ok = gen_server:call(Pid, {connect, {api, Config}}, 10 * 1000),
+	{ok, Pid}.
 
 -spec ssh_connect(string(), string(), integer(), string(), string()) -> {ok, pid()}.
 ssh_connect(Name, Host, Port, Login, Password) ->

--- a/src/core/me_logic.erl
+++ b/src/core/me_logic.erl
@@ -26,8 +26,12 @@ do_login(Socket, Login, Password) ->
 	Hash = count_hash(Password, Salt),
 	LoginRequest = form_login_sentence(Login, Hash),
 	me_api:write_sentence(Socket, LoginRequest),
-	{done, ["!done"]} = me_api:read_sentence(Socket),
-	ok.
+	case me_api:read_sentence(Socket) of
+		{done, ["!done"]} ->
+			ok;
+		{trap, ["!trap", "=message=cannot log in"]} ->
+			err
+	end.
 
 %% @private
 get_salt({done, LoginGreeting}) ->


### PR DESCRIPTION
Frequently I was experiencing failures to log in to the router (with correct credentials; I am not sure what the cause of the failures was), so I updated your code to handle such failures. I made the api_connect function wait for the result. Now, if the login fails (["!trap", "=message=cannot log in"] is received), it is repeated after one second - until the login succeeds. The code with this modification has been tested for over 2 months and works without problems.
